### PR TITLE
Add 'uvx' entry point for simplified MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,9 @@ You can easily integrate Code Index MCP with Claude Desktop:
    {
      "mcpServers": {
        "code-indexer": {
-         "command": "uv",
+         "command": "uvx",
          "args": [
-            "--directory",
-            "C:\\Users\\username\\path\\to\\code-index-mcp",
-            "run",
-            "run.py"
+            "C:\\Users\\username\\path\\to\\code-index-mcp"
           ]
        }
      }
@@ -77,19 +74,17 @@ You can easily integrate Code Index MCP with Claude Desktop:
    {
      "mcpServers": {
        "code-indexer": {
-         "command": "uv",
+         "command": "uvx",
          "args": [
-            "--directory",
-            "/home/username/path/to/code-index-mcp",
-            "run",
-            "run.py"
+            "/Users/username/path/to/code-index-mcp"
           ]
        }
      }
    }
    ```
 
-   **Note**: The `--directory` option is important as it ensures uv runs in the correct project directory and can properly load all dependencies.
+   **Note**: The tool can also be run directly with `uv run run.py` which may be useful for development and debugging.
+
 4. Restart Claude Desktop to use Code Indexer for analyzing code projects
 
 No manual dependency installation is required - UV will automatically handle all dependencies when running the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ Homepage = "https://github.com/yourusername/code-index-mcp"
 
 [project.scripts]
 code-indexer = "code_index_mcp.server:main"
+uvx = "code_index_mcp.server:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
This adds a new 'uvx' entry point that allows for simpler configuration when integrating the code-index-mcp server with Claude for Mac and Cursor. Documentation has been updated to show the new configuration patterns.